### PR TITLE
adding .eslintignore to not scan node_modules to fix travis-ci issue

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
adding .eslintignore file to prevent node_modules scans